### PR TITLE
[feat] parser구현

### DIFF
--- a/include/InstructionParser.h
+++ b/include/InstructionParser.h
@@ -1,14 +1,20 @@
 #pragma once
+#include <cstdint>
 
-// [Owner: A] 파일명: InstructionParser.h
-// [Role] 32bit 원시 명령어 → opcode/flag/operand 추출
-// [Interfaces] ParsedInstruction{opcode,flag,op1,op2}
-// [Notes] 비트 시프트/마스크 정확성, 엔디언 주의
+// [Owner: A]
+// [Role] 32bit 명령어 파싱 담당 (Opcode / Flag / Operand 추출)
+// [Note] 비트 연산 정확성 중요. 엔디언 문제, 매직넘버 주의.
+// [Output] ParsedInstruction {opcode, flag, op1, op2}
 
-// [담당: A] 32bit 원시 명령어 -> opcode/flag/operand 추출
-// [구성]
-// - struct ParsedInstruction { uint8_t opcode; uint8_t flag; uint8_t op1; uint8_t op2; };
-// - class InstructionParser { static ParsedInstruction parse(uint32_t raw); }
-//
-// [주의] 여기서는 선언 가이드만. 구현은 InstructionParser.cpp의 TODO로.
+struct ParsedInstruction {
+    std::uint8_t opcode{0};
+    std::uint8_t flag{0};
+    std::uint8_t op1{0};
+    std::uint8_t op2{0};
+};
+
+class InstructionParser {
+public:
+    static ParsedInstruction parse(std::uint32_t raw);
+};
 

--- a/src/InstructionParser.cpp
+++ b/src/InstructionParser.cpp
@@ -1,14 +1,25 @@
-// [Owner: A] 파일명: InstructionParser.cpp
-// [Role] 32bit 원시 명령어 → ParsedInstruction 파싱
-// [Interfaces] ParsedInstruction{opcode,flag,op1,op2}
-// [Notes] 비트 시프트/마스크 정확성, 엔디언 주의
+#include "InstructionParser.h"
 
-// [담당: A] 비트 파싱 TODO 가이드
-// - ParsedInstruction parse(uint32_t raw):
-//   opcode = (raw >> 26) & 0x3F
-//   flag   = (raw >> 24) & 0x03
-//   op1    = (raw >> 16) & 0xFF
-//   op2    = (raw >> 8)  & 0xFF
-// - 엔디언 주의 사항, reserved 8bit 무시
-// - 단위 테스트 포인트 주석
+// [Owner: A]
+// [Role] InstructionParser 구현 (비트 연산)
+// [Note] 비트 시프트 위치와 마스크의 일관성이 중요. 엔디언 주의.
+
+namespace {
+constexpr std::uint32_t OPCODE_MASK   = 0x3Fu;
+constexpr std::uint32_t FLAG_MASK     = 0x03u;
+constexpr std::uint32_t OPERAND_MASK  = 0xFFu;
+}  // namespace
+
+ParsedInstruction InstructionParser::parse(std::uint32_t raw) {
+    // Little-endian 입력을 가정.
+    // 과제 환경에서는 파일 생성 시점과 실행 환경의 엔디언이 동일하다고 가정하고 구현해도 무방함.
+    // 필요하다면 추후 바이트 스왑 함수를 추가하여 확장 가능.
+
+    const auto opcode = static_cast<std::uint8_t>((raw >> 26) & OPCODE_MASK);
+    const auto flag   = static_cast<std::uint8_t>((raw >> 24) & FLAG_MASK);
+    const auto op1    = static_cast<std::uint8_t>((raw >> 16) & OPERAND_MASK);
+    const auto op2    = static_cast<std::uint8_t>((raw >> 8)  & OPERAND_MASK);
+
+    return ParsedInstruction{opcode, flag, op1, op2};
+}
 


### PR DESCRIPTION
📝 Summary

32bit raw bytecode(바이너리 명령어)를
opcode / flag / operand1 / operand2 로 분해하는
InstructionParser 모듈을 구현했습니다.

이 파서는 VM의 실행 루프에서 사용되며,
이후 InstructionFactory가 명령어 객체 생성 시 필요로 하는 핵심 로직입니다.

🔧 Main Changes

ParsedInstruction 구조체 추가

InstructionParser::parse() 구현

비트 시프트(>>) + 마스크(&) 기반 파싱

opcode(6bit) / flag(2bit) / op1(8bit) / op2(8bit) 분리

매직 넘버 제거: constexpr MASK 상수 정의

엔디언 이슈 관련 주석 추가 (Little-endian Assume)

🧩 Why This Matters

VMContext의 fetchNext()가 반환하는 32bit 명령을
추상화된 구조체로 변환하는 역할

InstructionFactory에서 정확한 명령어 객체 생성을 위해 필수

전체 인터프리터 실행 흐름의 첫 번째 단계 구성

